### PR TITLE
chore: remove Python 3.8 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,10 @@ version = '0.0.64'
 authors = [{ name = 'questdb.io', email = 'miguel@questdb.io' }]
 description = "SqlAlchemy/Superset libraries."
 readme = "README.md"
-requires-python = "~=3.9"
+requires-python = ">=3.9,<3.12"
 classifiers = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11'


### PR DESCRIPTION
questdb-connect does not run on Python 3.8
