### PR TITLE
fix parameter name, user vs username

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 # https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/
 name = 'questdb-connect'
-version = '1.0.11' # Standalone production version (with engine)
-#version = '0.0.104' # testing version
+version = '1.0.12' # Standalone production version (with engine)
+# version = '0.0.105' # testing version
 authors = [{ name = 'questdb.io', email = 'miguel@questdb.io' }]
 description = "SqlAlchemy library"
 readme = "README.md"

--- a/src/questdb_connect/__init__.py
+++ b/src/questdb_connect/__init__.py
@@ -72,7 +72,7 @@ def cursor_factory(*args, **kwargs):
 def connect(**kwargs):
     host = kwargs.get("host") or "127.0.0.1"
     port = kwargs.get("port") or 8812
-    user = kwargs.get("username") or "admin"
+    user = kwargs.get("user") or "admin"
     password = kwargs.get("password") or "quest"
     database = kwargs.get("database") or "main"
     conn = psycopg2.connect(

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest.outcomes import fail
 from psycopg2 import OperationalError
 from sqlalchemy import create_engine
 
@@ -10,4 +11,5 @@ def test_user(test_engine, test_model):
     engine = create_engine("questdb://user1:quest@localhost:8812/qdb")
     with pytest.raises(OperationalError) as exc_info:
         engine.connect()
-    assert str(exc_info.value).__contains__("ERROR:  invalid username/password")
+    if not str(exc_info.value).__contains__("ERROR:  invalid username/password"):
+        fail()

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -1,0 +1,12 @@
+import pytest
+from sqlalchemy import create_engine
+
+
+def test_user(test_engine, test_model):
+    engine = create_engine("questdb://admin:quest@localhost:8812/qdb")
+    engine.connect()
+
+    engine = create_engine("questdb://user1:quest@localhost:8812/qdb")
+    with pytest.raises(Exception) as exc_info:
+        engine.connect()
+    assert str(exc_info.value).__contains__("ERROR:  invalid username/password")

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -1,4 +1,5 @@
 import pytest
+from psycopg2 import OperationalError
 from sqlalchemy import create_engine
 
 
@@ -7,6 +8,6 @@ def test_user(test_engine, test_model):
     engine.connect()
 
     engine = create_engine("questdb://user1:quest@localhost:8812/qdb")
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(OperationalError) as exc_info:
         engine.connect()
     assert str(exc_info.value).__contains__("ERROR:  invalid username/password")


### PR DESCRIPTION
incorrect parameter name usage (`username` vs `user`) resulted in defaulting the username always to `admin`