### PR TITLE
fix: remove timezone clobbering 

### DIFF
--- a/src/questdb_connect/__init__.py
+++ b/src/questdb_connect/__init__.py
@@ -43,15 +43,6 @@ from questdb_connect.types import (
     resolve_type_from_name,
 )
 
-# QuestDB timestamps: https://questdb.io/docs/guides/working-with-timestamps-timezones/
-# The native timestamp format used by QuestDB is a Unix timestamp in microsecond resolution.
-# Although timestamps in nanoseconds will be parsed, the output will be truncated to
-# microseconds. QuestDB does not store time zone information alongside timestamp values
-# and therefore it should be assumed that all timestamps are in UTC.
-if hasattr(time, "tzset"):
-    os.environ["TZ"] = "UTC"
-    time.tzset()
-
 # ===== DBAPI =====
 # https://peps.python.org/pep-0249/
 


### PR DESCRIPTION
Fixes https://github.com/questdb/questdb-connect/issues/12


**Test outputs**

```
make test
python3 -m pytest
====================================================================== test session starts =======================================================================
platform darwin -- Python 3.9.6, pytest-7.3.2, pluggy-1.5.0
rootdir: [snipped]
plugins: mock-3.11.1
collected 35 items                                                                                                                                               

tests/test_dialect.py ..........                                                                                                                           [ 28%]
tests/test_examples.py .....                                                                                                                               [ 42%]
tests/test_superset.py .................                                                                                                                   [ 91%]
tests/test_types.py ..                                                                                                                                     [ 97%]
tests/test_username.py .                                                                                                                                   [100%]

======================================================================== warnings summary ========================================================================
[snipped]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 35 passed, 12 warnings in 5.10s =================================================================
python3 -m black src
All done! ✨ 🍰 ✨
18 files left unchanged.
python3 -m ruff check src/questdb_connect --fix
python3 -m ruff check src/examples --fix
python3 -m ruff check tests --fix
```

```make docker-test
docker run -e QUESTDB_CONNECT_HOST='host.docker.internal' -e SQLALCHEMY_SILENCE_UBER_WARNING=1 questdb/questdb-connect:latest
rows: 1
{
    "col_boolean": "True",
    "col_byte": "8",
    "col_short": "12",
    "col_int": "13",
    "col_long": "14",
    "col_float": "15.234",
    "col_double": "16.88993244",
    "col_symbol": "coconut",
    "col_string": "banana",
    "col_char": "C",
    "col_uuid": "6d5eb038-63d1-4971-8484-30c16e13de5b",
    "col_date": "2023-04-22 00:00:00",
    "col_ts": "2023-04-22 18:10:10.765123",
    "col_geohash": "dfvgsj",
    "col_long256": "0xa3b400fcf6ed707d710d5d4e672305203ed3cc6254d1cefe313e4a465861f42a"
}
```