### PR TITLE
sqlalchemy readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,14 @@ using the raw SQL API, which allows direct interaction with QuestDB's time-serie
 query engine and provides better control over time-based operations.
 
 ## Superset Installation
+This repository also contains an engine specification for Apache Superset, which allows you to connect
+to QuestDB from within the Superset interface.
 
-<a href="https://superset.apache.org/docs/quickstart/" target="blank">
-    <img alt="Apache Superset" src="https://raw.githubusercontent.com/questdb/questdb-connect/refs/heads/main/docs/superset.png"/>
-</a>
+<img alt="Apache Superset" src="https://raw.githubusercontent.com/questdb/questdb-connect/refs/heads/main/docs/superset.png"/>
 
-Follow the instructions available [here](https://superset.apache.org/docs/quickstart/).
+
+Follow the official [QuestDB Superset guide](https://questdb.io/docs/third-party-tools/superset/) available on the
+QuestDB website to install and configure the QuestDB engine in Superset.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -62,54 +62,135 @@ questdb://admin:quest@host.docker.internal:8812/main
 ```
 
 From that point on use standard SQLAlchemy:
-
+Example with raw SQL API:
 ```python
 import datetime
-import os
-
-os.environ.setdefault('SQLALCHEMY_SILENCE_UBER_WARNING', '1')
-
-import questdb_connect.dialect as qdbc
-from sqlalchemy import Column, MetaData, create_engine, insert
-from sqlalchemy.orm import declarative_base
-
-Base = declarative_base(metadata=MetaData())
-
-
-class Signal(Base):
-    __tablename__ = 'signal'
-    __table_args__ = (qdbc.QDBTableEngine('signal', 'ts', qdbc.PartitionBy.HOUR, is_wal=True),)
-    source = Column(qdbc.Symbol)
-    value = Column(qdbc.Double)
-    ts = Column(qdbc.Timestamp, primary_key=True)
-
+import uuid
+from sqlalchemy import create_engine, text
 
 def main():
-    engine = create_engine('questdb://localhost:8812/main')
-    try:
-        Base.metadata.create_all(engine)
-        with engine.connect() as conn:
-            conn.execute(insert(Signal).values(
-                source='coconut',
-                value=16.88993244,
-                ts=datetime.datetime.utcnow()
-            ))
-    finally:
-        if engine:
-            engine.dispose()
+    engine = create_engine('questdb://admin:quest@localhost:8812/main')
+
+    with engine.begin() as connection:
+        # Create the table
+        connection.execute(text("""
+            CREATE TABLE IF NOT EXISTS signal (
+                source SYMBOL,
+                value DOUBLE,
+                ts TIMESTAMP,
+                uuid UUID
+            ) TIMESTAMP(ts) PARTITION BY HOUR WAL;
+        """))
+
+        # Insert 2 rows
+        connection.execute(text("""
+            INSERT INTO signal (source, value, ts, uuid) VALUES
+            (:source1, :value1, :ts1, :uuid1),
+            (:source2, :value2, :ts2, :uuid2)
+        """), {
+            'source1': 'coconut', 'value1': 16.88993244, 'ts1': datetime.datetime.utcnow(), 'uuid1': uuid.uuid4(),
+            'source2': 'banana', 'value2': 3.14159265, 'ts2': datetime.datetime.utcnow(), 'uuid2': uuid.uuid4()
+        })
+
+    # Start a new transaction
+    with engine.begin() as connection:
+        # Wait for all previous transactions to be applied to the table before querying
+        connection.execute(text("select wait_wal_table('signal')"))
+
+        # Query the table for rows where value > 10
+        result = connection.execute(
+            text("SELECT source, value, ts, uuid FROM signal WHERE value > :value"),
+            {'value': 10}
+        )
+        for row in result:
+            print(row.source, row.value, row.ts, row.uuid)
 
 
 if __name__ == '__main__':
     main()
 ```
 
+Alternatively, you can use the ORM API:
+```python
+import datetime
+import uuid
+import questdb_connect as qdbc
+from sqlalchemy import Column, MetaData, create_engine, text
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+Base = declarative_base(metadata=MetaData())
+
+
+class Signal(Base):
+    # Stored in a QuestDB table 'signal'. The tables has WAL enabled, is partitioned by hour, designated timestamp is 'ts'
+    __tablename__ = 'signal'
+    __table_args__ = (qdbc.QDBTableEngine(None, 'ts', qdbc.PartitionBy.HOUR, is_wal=True),)
+    source = Column(qdbc.Symbol)
+    value = Column(qdbc.Double)
+    ts = Column(qdbc.Timestamp)
+    uuid = Column(qdbc.UUID, primary_key=True)
+
+    def __repr__(self):
+        return f"Signal(source={self.source}, value={self.value}, ts={self.ts}, uuid={self.uuid})"
+
+
+def main():
+    engine = create_engine('questdb://admin:quest@localhost:8812/main')
+
+    # Create the table
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    # Insert 2 rows
+    session.add(Signal(
+        source='coconut',
+        value=16.88993244,
+        ts=datetime.datetime.utcnow(),
+        uuid=uuid.uuid4()
+    ))
+
+    session.add(Signal(
+        source='banana',
+        value=3.14159265,
+        ts=datetime.datetime.utcnow(),
+        uuid=uuid.uuid4()
+    ))
+
+
+    session.commit()
+
+    # Wait for the WAL to be applied to the table before querying
+    with engine.connect() as connection:
+        connection.execute(text("select wait_wal_table('signal')"))
+
+    # Query the table for rows where value > 10
+    signals = session.query(Signal).filter(Signal.value > 10).all()
+    for signal in signals:
+        print(signal.source, signal.value, signal.ts, signal.uuid)
+
+
+if __name__ == '__main__':
+    main()
+```
+ORM (Object-Relational Mapping) API is not recommended for QuestDB due to its fundamental
+design differences from traditional transactional databases. While ORMs excel at managing
+relationships and complex object mappings in systems like PostgreSQL or MySQL, QuestDB is
+specifically optimized for time-series data operations and high-performance ingestion. It
+intentionally omits certain SQL features that ORMs typically rely on, such as generated
+columns, foreign keys, and complex joins, in favor of time-series-specific optimizations.
+
+For optimal performance and to fully leverage QuestDB's capabilities, we strongly recommend
+using the raw SQL API, which allows direct interaction with QuestDB's time-series-focused
+query engine and provides better control over time-based operations.
+
 ## Superset Installation
 
-<a href="https://superset.apache.org/docs/installation/installing-superset-from-scratch/" target="blank">
-    <img alt="Apache Superset" src="https://github.com/questdb/questdb-connect/blob/main/docs/superset.png"/>
+<a href="https://superset.apache.org/docs/quickstart/" target="blank">
+    <img alt="Apache Superset" src="https://raw.githubusercontent.com/questdb/questdb-connect/refs/heads/main/docs/superset.png"/>
 </a>
 
-Follow the instructions available [here](https://superset.apache.org/docs/installation/installing-superset-from-scratch/).
+Follow the instructions available [here](https://superset.apache.org/docs/quickstart/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ questdb://admin:quest@localhost:8812/main
 questdb://admin:quest@host.docker.internal:8812/main
 ```
 
-From that point on use standard SQLAlchemy:
-Example with raw SQL API:
+From that point on use standard SQLAlchemy. Example with raw SQL API:
 ```python
 import datetime
 import time

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ When using SQLAlchemy with QuestDB:
 - You can define primary keys in your SQLAlchemy models, but QuestDB won't enforce uniqueness for individual columns
 - Duplicate rows with identical primary key values can exist in the database
 - Data integrity must be managed at the application level
-- QuestDB support deduplication during ingestion to avoid data duplication, this can be enabled in the table creation
+- QuestDB support [deduplication](https://questdb.io/docs/concept/deduplication/) during ingestion to avoid data duplication, this can be enabled in the table creation
 
 ### Recommended Approaches
 


### PR DESCRIPTION
1. ORM example fixed - import fixed, uses UUID as a primary key, show querying and use a bit more idiomatic code in general
2. Added RAW SQL example
3. Guidance added - basically a warning against ORM

I tested both ORM and raw SQL examples with SQLAlchemy 1.4 and 2.0