### PR TITLE
Add support for QuestDB's LIMIT clause in SQLAlchemy dialect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ max-branches = 20
 max-args = 10
 
 [tool.ruff.per-file-ignores]
-'tests/test_dialect.py' = ['S101']
+'tests/test_dialect.py' = ['S101', 'PLR2004']
 'tests/test_types.py' = ['S101']
 'tests/test_superset.py' = ['S101']
 'tests/conftest.py' = ['S608']

--- a/src/questdb_connect/compilers.py
+++ b/src/questdb_connect/compilers.py
@@ -30,9 +30,42 @@ class QDBDDLCompiler(sqlalchemy.sql.compiler.DDLCompiler, abc.ABC):
 
 
 class QDBSQLCompiler(sqlalchemy.sql.compiler.SQLCompiler, abc.ABC):
+    # Maximum value for 64-bit signed integer (2^63 - 1)
+    BIGINT_MAX = 9223372036854775807
+
     def _is_safe_for_fast_insert_values_helper(self):
         return True
 
     def visit_textclause(self, textclause, add_to_result_map=None, **kw):
         textclause.text = remove_public_schema(textclause.text)
         return super().visit_textclause(textclause, add_to_result_map, **kw)
+
+    def limit_clause(self, select, **kw):
+        """
+        Generate QuestDB-style LIMIT clause from SQLAlchemy select statement.
+        QuestDB supports arbitrary expressions in LIMIT clause.
+        """
+        text = ""
+        limit = select._limit_clause
+        offset = select._offset_clause
+
+        if limit is None and offset is None:
+            return text
+
+        text += "\n LIMIT "
+
+        # Handle cases based on presence of limit and offset
+        if limit is not None and offset is not None:
+            # Convert LIMIT x OFFSET y to LIMIT y,y+x
+            lower_bound = self.process(offset, **kw)
+            limit_val = self.process(limit, **kw)
+            text += f"{lower_bound},{lower_bound} + {limit_val}"
+
+        elif limit is not None:
+            text += self.process(limit, **kw)
+
+        elif offset is not None:
+            # If only offset is specified, use max bigint as upper bound
+            text += f"{self.process(offset, **kw)},{self.BIGINT_MAX}"
+
+        return text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import time
 from typing import NamedTuple
 
 import pytest
@@ -124,6 +125,36 @@ def collect_select_all(session, expected_rows) -> str:
         rs = session.execute(text(f'select * from public.{ALL_TYPES_TABLE_NAME} order by 1 asc'))
         if rs.rowcount == expected_rows:
             return '\n'.join(str(row) for row in rs)
+
+
+def wait_until_table_is_ready(test_engine, table_name, expected_rows, timeout=10):
+    """
+    Wait until a table has the expected number of rows, with timeout.
+
+    Args:
+        test_engine: SQLAlchemy engine
+        table_name: Name of the table to check
+        expected_rows: Expected number of rows
+        timeout: Maximum time to wait in seconds (default: 10 seconds)
+
+    Returns:
+        bool: True if table is ready, False if timeout occurred
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: If there's a database error
+    """
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        with test_engine.connect() as conn:
+            result = conn.execute(text(f'SELECT count(*) FROM {table_name}'))
+            row = result.fetchone()
+            if row and row[0] == expected_rows:
+                return True
+
+            print(f'Waiting for table {table_name} to have {expected_rows} rows, current: {row[0] if row else 0}')
+            time.sleep(0.01)  # Wait 10ms between checks
+    return False
 
 
 def collect_select_all_raw_connection(test_engine, expected_rows) -> str:


### PR DESCRIPTION
Implements QuestDB's LIMIT clause in SQLAlchemy dialect. Key features:

- Standard LIMIT N syntax
- LIMIT lower,upper range syntax (lower exclusive, upper inclusive)
- Support for expressions and bind parameters
- Automatic conversion of SQLAlchemy's LIMIT/OFFSET


Example:
```python
select(table).limit(5)               # LIMIT 5
select(table).limit(3).offset(2)     # LIMIT 2,5
select(table).offset(8)              # LIMIT 8,BIGINT_MAX
```

This addressed the 2nd bullet from https://github.com/questdb/questdb-connect/issues/25